### PR TITLE
Fix Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // Set `base` to '/REPO/' when deploying under https://USER.github.io/REPO/
 export default defineConfig({
   plugins: [react()],
-  base: '/Eng_Mobilization_Calc_Tool/',
+  base: '/Cjbr-Mobilization_Calc_Tool/',
 })


### PR DESCRIPTION
## Summary
- point Vite's `base` option to `/Cjbr-Mobilization_Calc_Tool/` so static assets load correctly on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9616d11dc832eb6f5827b7a377122