### PR TITLE
Add export and backup controls for mobilization scenarios

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -29,3 +29,4 @@ textarea { @apply min-h-[80px]; }
 .pill { @apply inline-block px-2 py-0.5 rounded-full border border-[color:var(--border)] ml-2 text-xs; }
 .total { @apply font-bold; }
 .role { @apply bg-[#0c1430] border border-dashed border-[color:var(--border)] p-3 rounded-2xl; }
+.actions { @apply flex flex-wrap gap-2 my-4; }


### PR DESCRIPTION
## Summary
- add validation helpers to restore previously saved scenarios safely
- add Excel export, backup save, and backup load controls with hidden file input
- persist the working scenario to localStorage and style the new action buttons

## Testing
- `npm run build` *(fails: Permission denied executing the repo-provided vite binary in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da2951969c832eb469f1d395ea1881