### PR TITLE
Update incidentals allowance label to Others per day

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -428,7 +428,7 @@ export default function App(){
               <div><label className="label">Hotel / night</label><input value={sc.allowances.hotelPerNight} onChange={e=> setSc({...sc, allowances:{...sc.allowances, hotelPerNight:e.target.value}})} /></div>
               <div><label className="label">Meals / day</label><input value={sc.allowances.mealsPerDay} onChange={e=> setSc({...sc, allowances:{...sc.allowances, mealsPerDay:e.target.value}})} /></div>
               <div><label className="label">Laundry / week</label><input value={sc.allowances.laundryPerWeek} onChange={e=> setSc({...sc, allowances:{...sc.allowances, laundryPerWeek:e.target.value}})} /></div>
-              <div><label className="label">Incidentals / day</label><input value={sc.allowances.incidentalsPerDay} onChange={e=> setSc({...sc, allowances:{...sc.allowances, incidentalsPerDay:e.target.value}})} /></div>
+              <div><label className="label">Others / day</label><input value={sc.allowances.incidentalsPerDay} onChange={e=> setSc({...sc, allowances:{...sc.allowances, incidentalsPerDay:e.target.value}})} /></div>
             </div>
             <div className="mt-1 text-sm" style={{color:'var(--muted)'}}>Allowances total: <span className="total">{fmt(perDiemTotal, sc.currency.base)}</span></div>
           </Card>


### PR DESCRIPTION
## Summary
- rename the allowances incidentals label to display "Others / day"

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: vite binary not executable in repo copy)*
- node node_modules/vite/bin/vite.js --host 0.0.0.0 --port 4173 *(fails: missing optional rollup dependency in packaged node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e419605afc832e80513eb5c38a9d11